### PR TITLE
Add UnivEq[sci.Map[A, B]] to ScalaUnivEq

### DIFF
--- a/univeq/shared/src/main/scala-2.13/ScalaUnivEq.scala
+++ b/univeq/shared/src/main/scala-2.13/ScalaUnivEq.scala
@@ -29,6 +29,7 @@ trait ScalaUnivEq {
   // scala.collection.immutable
   @inline implicit def univEqSciArraySeq  [A: UnivEq           ]: UnivEq[sci.ArraySeq  [A]   ] = force
   @inline implicit def univEqSciBitSet    [A: UnivEq           ]: UnivEq[sci.BitSet          ] = force
+  @inline implicit def univEqScalaMap     [A: UnivEq, B: UnivEq]: UnivEq[sci.Map       [A, B]] = force
   @inline implicit def univEqSciHashMap   [A: UnivEq, B: UnivEq]: UnivEq[sci.HashMap   [A, B]] = force
   @inline implicit def univEqSciHashSet   [A: UnivEq           ]: UnivEq[sci.HashSet   [A]   ] = force
   @inline implicit def univEqSciIndexedSeq[A: UnivEq           ]: UnivEq[sci.IndexedSeq[A]   ] = force


### PR DESCRIPTION
The UnivEq for scala.collection.immutable.Map is now missing for Scala 2.13